### PR TITLE
feat: #8 - cuando se marque como done un TODO salga una animación de confetis por los lados de la pantalla

### DIFF
--- a/app_docs/conditional_docs.md
+++ b/app_docs/conditional_docs.md
@@ -22,3 +22,10 @@ Este documento te ayuda a determinar que documentacion deberias leer en funcion 
     - Cuando trabajes con cualquier cosa bajo frontend/
     - Cuando necesites saber como arrancar o testear la aplicacion React
     - Cuando trabajes con componentes, servicios o estilos del frontend
+
+- app_docs/feature-8-confetti-animation.md
+  - Condiciones:
+    - Cuando se trabaje con la animacion de confetis o feedback visual al completar tareas
+    - Cuando se implemente o modifique `handleToggleTask` en `App.jsx`
+    - Cuando se trabaje con `canvas-confetti` o el modulo `frontend/src/utils/confetti.js`
+    - Cuando se resuelvan problemas relacionados con animaciones en el frontend

--- a/app_docs/feature-8-confetti-animation.md
+++ b/app_docs/feature-8-confetti-animation.md
@@ -1,0 +1,71 @@
+# Feature: Animacion de Confetis al Completar un TODO
+
+**ADW ID:** /home/emartinez/work/adw-todo-app-demo/trees/issue-8/.issues/8/plan.md
+**Fecha:** 2026-03-05
+**Especificacion:** N/A
+
+## Overview
+
+Se anadio una animacion de confetis que se dispara cuando el usuario marca una tarea como completada. Usa la libreria `canvas-confetti` para lanzar particulas desde ambos lados de la pantalla, proporcionando feedback visual positivo al completar tareas. La animacion solo se activa al marcar como completado, no al desmarcar.
+
+## Que se Construyo
+
+- Modulo utilitario `confetti.js` que encapsula la logica de animacion con `canvas-confetti`
+- Integracion en `handleToggleTask` de `App.jsx` condicionada al cambio de estado incompleto -> completo
+- Tests unitarios para verificar que `fireConfetti` dispara dos rafagas (izquierda y derecha)
+- Tests de integracion en `App.test.jsx` para verificar el comportamiento de disparo/no-disparo segun el estado de la tarea
+
+## Implementacion Tecnica
+
+### Ficheros Modificados
+
+- `frontend/package.json`: Anadida dependencia `canvas-confetti`
+- `frontend/src/App.jsx`: Importa `fireConfetti` y la llama en `handleToggleTask` cuando `task.completed === false`
+- `frontend/src/__tests__/App.test.jsx`: Anadidos 2 tests de integracion para verificar logica de confeti
+- `frontend/src/utils/confetti.js` (nuevo): Modulo con funcion `fireConfetti()` que lanza dos rafagas de confetis
+
+### Cambios Clave
+
+- `fireConfetti()` lanza dos llamadas a `canvas-confetti`: una desde la izquierda (`angle: 60, origin.x: 0`) y otra desde la derecha (`angle: 120, origin.x: 1`), ambas a altura media (`origin.y: 0.6`)
+- La condicion en `handleToggleTask` es `if (!task.completed) fireConfetti()` — se evalua el estado actual antes del toggle
+- La llamada a `fireConfetti()` ocurre antes del `await updateTask` para feedback inmediato al usuario
+- Los tests mockean `canvas-confetti` con `vi.mock` para evitar dependencias del DOM en el entorno de test
+
+## Como Usar
+
+1. Abrir la aplicacion Todo List en el navegador
+2. Crear una nueva tarea si no existe ninguna
+3. Hacer clic en el checkbox de una tarea pendiente
+4. La animacion de confetis se lanzara desde ambos lados de la pantalla
+5. Al desmarcar una tarea completada, no se muestra animacion
+
+## Configuracion
+
+No requiere configuracion adicional. La dependencia `canvas-confetti` se instala via npm:
+
+```bash
+cd frontend && npm install
+```
+
+Los parametros de la animacion estan en `frontend/src/utils/confetti.js`:
+- `particleCount: 80` — numero de particulas por rafaga
+- `spread: 70` — angulo de dispersion
+- `startVelocity: 45` — velocidad inicial
+- `colors` — array de colores RGB en hex
+
+## Testing
+
+```bash
+cd frontend && npm test -- --run
+```
+
+Tests relevantes en `frontend/src/__tests__/`:
+- `App.test.jsx`: "fireConfetti is called when toggling incomplete task to complete"
+- `App.test.jsx`: "fireConfetti is NOT called when toggling complete task to incomplete"
+- `confetti.test.js`: Tests unitarios de la funcion `fireConfetti`
+
+## Notas
+
+- `canvas-confetti` (~6KB gzipped, sin dependencias) gestiona su propio canvas HTML, sin impacto en CSS ni estructura DOM existente
+- La animacion no bloquea la interaccion del usuario (es puramente visual y no-bloqueante)
+- No requiere cambios en el backend; la funcionalidad es 100% frontend

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "canvas-confetti": "^1.9.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -1753,6 +1754,15 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.4.tgz",
+      "integrity": "sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/chai": {
       "version": "5.3.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "canvas-confetti": "^1.9.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import TaskForm from './components/TaskForm'
 import TaskList from './components/TaskList'
 import { fetchTasks, createTask, updateTask, deleteTask, reorderTasks } from './services/api'
+import { fireConfetti } from './utils/confetti'
 
 function App() {
   const [tasks, setTasks] = useState([])
@@ -23,6 +24,7 @@ function App() {
 
   const handleToggleTask = async (id) => {
     const task = tasks.find(t => t.id === id)
+    if (!task.completed) fireConfetti()
     setTasks(tasks.map(t => t.id === id ? { ...t, completed: !t.completed } : t))
     await updateTask(id, { completed: !task.completed })
   }

--- a/frontend/src/__tests__/App.test.jsx
+++ b/frontend/src/__tests__/App.test.jsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import App from '../App'
 import { fetchTasks, updateTask } from '../services/api'
+import { fireConfetti } from '../utils/confetti'
 
 // Mock del servicio API
 vi.mock('../services/api', () => ({
@@ -9,6 +10,10 @@ vi.mock('../services/api', () => ({
   updateTask: vi.fn().mockResolvedValue({}),
   deleteTask: vi.fn(),
   reorderTasks: vi.fn().mockResolvedValue([])
+}))
+
+vi.mock('../utils/confetti', () => ({
+  fireConfetti: vi.fn(),
 }))
 
 test('renders Todo List heading', () => {
@@ -49,4 +54,31 @@ test('toggle calls updateTask with completed: false when task is completed', asy
   await waitFor(() => {
     expect(updateTask).toHaveBeenCalledWith(1, { completed: false })
   })
+})
+
+test('fireConfetti is called when toggling incomplete task to complete', async () => {
+  fireConfetti.mockClear()
+  fetchTasks.mockResolvedValue([{ id: 1, title: 'Test task', completed: false }])
+
+  render(<App />)
+  const checkbox = await screen.findByRole('checkbox')
+  fireEvent.click(checkbox)
+
+  await waitFor(() => {
+    expect(fireConfetti).toHaveBeenCalledTimes(1)
+  })
+})
+
+test('fireConfetti is NOT called when toggling complete task to incomplete', async () => {
+  fireConfetti.mockClear()
+  fetchTasks.mockResolvedValue([{ id: 1, title: 'Test task', completed: true }])
+
+  render(<App />)
+  const checkbox = await screen.findByRole('checkbox')
+  fireEvent.click(checkbox)
+
+  await waitFor(() => {
+    expect(updateTask).toHaveBeenCalledWith(1, { completed: false })
+  })
+  expect(fireConfetti).not.toHaveBeenCalled()
 })

--- a/frontend/src/__tests__/confetti.test.js
+++ b/frontend/src/__tests__/confetti.test.js
@@ -1,0 +1,30 @@
+import { fireConfetti } from '../utils/confetti'
+
+vi.mock('canvas-confetti', () => ({
+  default: vi.fn(),
+}))
+
+import confetti from 'canvas-confetti'
+
+test('fireConfetti calls canvas-confetti twice', () => {
+  fireConfetti()
+  expect(confetti).toHaveBeenCalledTimes(2)
+})
+
+test('fireConfetti fires from left side', () => {
+  confetti.mockClear()
+  fireConfetti()
+  expect(confetti).toHaveBeenCalledWith(expect.objectContaining({
+    angle: 60,
+    origin: expect.objectContaining({ x: 0 }),
+  }))
+})
+
+test('fireConfetti fires from right side', () => {
+  confetti.mockClear()
+  fireConfetti()
+  expect(confetti).toHaveBeenCalledWith(expect.objectContaining({
+    angle: 120,
+    origin: expect.objectContaining({ x: 1 }),
+  }))
+})

--- a/frontend/src/utils/confetti.js
+++ b/frontend/src/utils/confetti.js
@@ -1,0 +1,23 @@
+import confetti from 'canvas-confetti'
+
+export function fireConfetti() {
+  const colors = ['#ff0000', '#00ff00', '#0000ff', '#ffff00', '#ff00ff', '#00ffff']
+
+  confetti({
+    particleCount: 80,
+    spread: 70,
+    startVelocity: 45,
+    angle: 60,
+    origin: { x: 0, y: 0.6 },
+    colors,
+  })
+
+  confetti({
+    particleCount: 80,
+    spread: 70,
+    startVelocity: 45,
+    angle: 120,
+    origin: { x: 1, y: 0.6 },
+    colors,
+  })
+}


### PR DESCRIPTION
## Summary

Implements a confetti animation that triggers when a TODO item is marked as done. The animation displays confetti bursting from both sides of the screen to celebrate task completion.

Closes #8

## Implementation Plan
See implementation plan in issue #8 comments

## Changes

- Added `canvas-confetti` library to frontend dependencies
- Created `frontend/src/utils/confetti.js` utility with a `triggerConfetti` function that fires confetti from both left and right sides of the screen
- Integrated `triggerConfetti` call in `frontend/src/App.jsx` when a TODO is toggled to done
- Added unit tests in `frontend/src/__tests__/confetti.test.js` for the confetti utility
- Added integration tests in `frontend/src/__tests__/App.test.jsx` verifying confetti fires on done and not on undone
- Added feature documentation in `app_docs/feature-8-confetti-animation.md`
- Updated `app_docs/conditional_docs.md` with reference to the new feature doc

## ADW
ADW ID: d5803b27
